### PR TITLE
add base plugin to root project for lifecycle tasks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    base
+}
+
 repositories {
     mavenCentral()
     mavenLocal()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,6 +8,8 @@ pluginManagement {
 }
 
 include(
+    ":",
+
     ":modules:example-module:common",
     ":modules:example-module:gateway",
 


### PR DESCRIPTION
Hey Ben,

Thanks for sharing this repo, hopefully you'll be amused that it was a very minor issue that I've fixed in this PR.  You're seeing an error because you are running `./gradlew assemble` or `./gradlew :assemble`.  The tricky thing about `./gradlew assemble` is that it will call an `assemble` task on every project in the gradle build.  While you don't define a root project `":"` in your _settings.gradle.kts#include_, all gradle builds have a root project implicitly, regardless of whether or not you define one (which makes sense if you think about having the `rootProject.projectName=...` in the settings file).

So when you run `./gradlew assemble`, it's calling assemble on the root project (`:assemble`), and there is no assemble task on the root project because no plugins are defined defined.  So I've simple added Gradle's [Base Plugin](https://docs.gradle.org/current/userguide/base_plugin.html), which establishes some basic lifecycle tasks that are generally considered best practice to have.   

Let me know if this fixes the issue for you over in the [Issue you opened](https://github.com/inductiveautomation/ignition-module-tools/issues/44).

-Perry 